### PR TITLE
Add Taipei node (Hackapei, hackapei.com)

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,6 +530,10 @@
     </div>
     <div class="button-container" id="nodes-container">
       <!-- Nodes loaded dynamically from API -->
+      <a href="https://hackapei.com" class="button">
+        <div class="button-title"><span>Hackapei 🇹🇼</span></div>
+        <div class="button-details">Taipei · Est. 2026</div>
+      </a>
     </div>
     <div id="recent-meetups-container" style="display: none;">
       <div class="people-section-title">Recent Meetups</div>


### PR DESCRIPTION
Adds the **Taipei** chapter — **Hackapei** ([hackapei.com](https://hackapei.com)) — to the network, per `hackanew.md` step 8.

| Field | Value |
|---|---|
| Name | Hackapei 🇹🇼 |
| URL | https://hackapei.com |
| Location | Taipei |
| Established | 2026 |

> Heads up: the live node list renders from the `hackabot` API (`/api/nodes/`), so to appear on the site this node likely also needs adding to the `hacka-network/hackabot` backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)